### PR TITLE
Fix IndexOutOfRange when stunned hero dies

### DIFF
--- a/team-1 project/src/main/java/com/codingame/game/Player.java
+++ b/team-1 project/src/main/java/com/codingame/game/Player.java
@@ -33,12 +33,11 @@ public class Player extends AbstractPlayer {
         int outputCounter = 0;
         for (int i = 0; i < internalHeroes.size(); i++) {
             Hero hero = internalHeroes.get(i);
-            if(hero.stunTime > 0){
-                outputCounter++;
+            if (hero.isDead) {
                 continue;
             }
-
-            if (hero.isDead) {
+            if(hero.stunTime > 0){
+                outputCounter++;
                 continue;
             }
 


### PR DESCRIPTION
When stunned hero dies outputCounter still increments and this is a IndexOutOfRange in outputs[outputCounter++].